### PR TITLE
feat: add PostgreSQL support alongside SQLite (#61)

### DIFF
--- a/news-aggregator/.env.example
+++ b/news-aggregator/.env.example
@@ -17,8 +17,15 @@ OPENROUTER_MODEL=mistralai/mistral-7b-instruct:free
 # Database Configuration
 # =============================================================================
 
-# SQLite database path (relative to backend directory)
+# SQLite (default, simple setup)
 DATABASE_URL=sqlite+aiosqlite:///./data/liga_news.db
+
+# PostgreSQL (recommended for production with multiple workers)
+# DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/liga_news
+
+# For Docker Compose with PostgreSQL:
+# DATABASE_URL=postgresql+asyncpg://liga:${POSTGRES_PASSWORD}@db:5432/liga_news
+# POSTGRES_PASSWORD=your-secure-password
 
 # =============================================================================
 # Application Settings

--- a/news-aggregator/.github/workflows/test.yml
+++ b/news-aggregator/.github/workflows/test.yml
@@ -1,0 +1,109 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  test-sqlite:
+    name: Test (SQLite)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio pytest-cov
+
+      - name: Run tests (SQLite)
+        run: pytest --cov=. --cov-report=xml -v
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        if: github.event_name == 'push'
+        with:
+          files: backend/coverage.xml
+          flags: sqlite
+          fail_ci_if_error: false
+
+  test-postgres:
+    name: Test (PostgreSQL)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_DB: test_liga
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio
+
+      - name: Run tests (PostgreSQL)
+        env:
+          TEST_DATABASE_URL: postgresql+asyncpg://test:test@localhost:5432/test_liga
+        run: pytest -v
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install linters
+        run: pip install ruff
+
+      - name: Run ruff check
+        run: ruff check .
+
+      - name: Run ruff format check
+        run: ruff format --check .

--- a/news-aggregator/backend/Dockerfile
+++ b/news-aggregator/backend/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.12-slim AS base
 # Install system dependencies (including Playwright browser deps)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
-    sqlite3 gzip bc \
+    sqlite3 postgresql-client gzip bc \
     # Playwright/Chromium dependencies
     libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
     libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 \

--- a/news-aggregator/backend/api/admin.py
+++ b/news-aggregator/backend/api/admin.py
@@ -446,8 +446,9 @@ async def classify_items_for_confidence(
 
     # Filter by confidence (unless force)
     if not force:
+        from database import json_extract_path
         query = query.where(
-            func.json_extract(Item.metadata_, "$.pre_filter.relevance_confidence").is_(None)
+            json_extract_path(Item.metadata_, "pre_filter", "relevance_confidence").is_(None)
         )
 
     # Filter to retry queue only

--- a/news-aggregator/backend/database.py
+++ b/news-aggregator/backend/database.py
@@ -1,12 +1,15 @@
 """Database setup and session management."""
 
 import asyncio
+import os
 from collections.abc import AsyncGenerator
+from typing import Any
 
-from sqlalchemy import event, text
+from sqlalchemy import event, func, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
-from sqlalchemy.pool import StaticPool
+from sqlalchemy.pool import NullPool
+from sqlalchemy.sql.elements import ColumnElement
 
 from config import settings
 
@@ -17,25 +20,70 @@ class Base(DeclarativeBase):
     pass
 
 
+def _get_database_url() -> str:
+    """Get the current database URL, respecting test overrides."""
+    # Check for test database URL override first
+    test_url = os.environ.get("TEST_DATABASE_URL")
+    if test_url:
+        return test_url
+    return settings.database_url
+
+
+def is_sqlite() -> bool:
+    """Check if the current database is SQLite."""
+    return "sqlite" in _get_database_url()
+
+
+def is_postgresql() -> bool:
+    """Check if the current database is PostgreSQL."""
+    url = _get_database_url()
+    return "postgresql" in url or "postgres" in url
+
+
+def json_extract_path(column: Any, *path: str) -> ColumnElement:
+    """Extract a value from a JSON column, database-agnostic.
+
+    Args:
+        column: The JSON column to extract from
+        *path: JSON path segments (e.g., 'llm_analysis', 'assigned_ak')
+
+    Returns:
+        SQLAlchemy expression that works on both SQLite and PostgreSQL
+    """
+    if is_sqlite():
+        # SQLite: json_extract(col, '$.key1.key2')
+        json_path = "$." + ".".join(path)
+        return func.json_extract(column, json_path)
+    else:
+        # PostgreSQL: Use jsonb_extract_path_text() function
+        # This works with both JSON and JSONB columns
+        # Cast JSON to JSONB for compatibility
+        from sqlalchemy import cast
+        from sqlalchemy.dialects.postgresql import JSONB
+        return func.jsonb_extract_path_text(cast(column, JSONB), *path)
+
+
 # Global lock for serializing database writes in parallel fetch scenarios
 # This allows network I/O to run in parallel while database writes are serialized
 db_write_lock = asyncio.Lock()
 
 # SQLite connection options for concurrent access
-# Using StaticPool with a single connection to avoid lock contention
-connect_args = {}
-if "sqlite" in settings.database_url:
+connect_args: dict[str, Any] = {}
+if is_sqlite():
     connect_args = {
         "timeout": 60,  # Wait up to 60 seconds for locks
         "check_same_thread": False,  # Allow multi-thread access
     }
 
+# Use NullPool for SQLite to avoid connection pool issues
+# PostgreSQL uses the default QueuePool for connection pooling
+pool_class = NullPool if is_sqlite() else None
+
 engine = create_async_engine(
     settings.database_url,
     echo=settings.debug,
     connect_args=connect_args,
-    # Use NullPool for SQLite to avoid connection pool issues
-    # Each session will create and close its own connection
+    poolclass=pool_class,
 )
 
 async_session_maker = async_sessionmaker(
@@ -59,9 +107,9 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
 async def init_db() -> None:
     """Initialize database tables."""
     async with engine.begin() as conn:
-        # Enable WAL mode for better concurrent access
+        # Enable WAL mode for better concurrent access (SQLite only)
         # WAL mode allows concurrent readers with a single writer
-        if "sqlite" in settings.database_url:
+        if is_sqlite():
             await conn.execute(text("PRAGMA journal_mode=WAL"))
             await conn.execute(text("PRAGMA busy_timeout=30000"))  # 30 seconds
             await conn.execute(text("PRAGMA synchronous=NORMAL"))  # Faster writes, still safe with WAL

--- a/news-aggregator/backend/requirements.txt
+++ b/news-aggregator/backend/requirements.txt
@@ -5,6 +5,8 @@ uvicorn[standard]>=0.32.0
 # Database
 sqlalchemy[asyncio]>=2.0.0
 aiosqlite>=0.20.0
+asyncpg>=0.30.0
+psycopg[binary]>=3.2.0
 alembic>=1.14.0
 
 # HTTP client

--- a/news-aggregator/backend/services/llm_worker.py
+++ b/news-aggregator/backend/services/llm_worker.py
@@ -224,7 +224,8 @@ class LLMWorker:
 
         # Query backlog items ordered by priority
         async with async_session_maker() as db:
-            retry_priority = func.json_extract(Item.metadata_, "$.retry_priority")
+            from database import json_extract_path
+            retry_priority = json_extract_path(Item.metadata_, "retry_priority")
             priority_order = case(
                 (retry_priority == "high", 1),
                 (retry_priority == "unknown", 2),

--- a/news-aggregator/backend/services/scheduler.py
+++ b/news-aggregator/backend/services/scheduler.py
@@ -451,13 +451,11 @@ async def retry_llm_processing(batch_size: int = 10) -> dict:
 
     async with async_session_maker() as db:
         # Query items needing LLM processing, ordered by priority
-        # Priority order: high > unknown > edge_case
-        # Use SQLite json_extract function for compatibility
-        from sqlalchemy import func
-
         # Priority order: high > unknown > edge_case > low
         # "low" items are certainly irrelevant (confidence < 0.25)
-        retry_priority = func.json_extract(Item.metadata_, "$.retry_priority")
+        from database import json_extract_path
+
+        retry_priority = json_extract_path(Item.metadata_, "retry_priority")
         priority_order = case(
             (retry_priority == "high", 1),
             (retry_priority == "unknown", 2),

--- a/news-aggregator/backend/tests/conftest.py
+++ b/news-aggregator/backend/tests/conftest.py
@@ -1,6 +1,7 @@
 """Pytest configuration and fixtures."""
 
 import asyncio
+import os
 from collections.abc import AsyncGenerator, Generator
 from datetime import datetime, timedelta
 from typing import Any
@@ -14,8 +15,12 @@ from database import Base, get_db
 from main import app
 from models import Channel, ConnectorType, Item, Priority, Rule, RuleType, Setting, Source
 
-# Use in-memory SQLite for tests
-TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+# Allow PostgreSQL testing via environment variable
+# Default to in-memory SQLite for fast local tests
+TEST_DATABASE_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "sqlite+aiosqlite:///:memory:"
+)
 
 
 @pytest.fixture(scope="session")

--- a/news-aggregator/docker-compose.postgres.yml
+++ b/news-aggregator/docker-compose.postgres.yml
@@ -1,0 +1,82 @@
+# Docker Compose for PostgreSQL deployment
+# Usage: docker compose -f docker-compose.postgres.yml up -d
+#
+# This file provides PostgreSQL as the database backend instead of SQLite.
+# Use this for production deployments with multiple workers or higher concurrency needs.
+
+services:
+  db:
+    image: postgres:17-alpine
+    container_name: liga-news-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: liga_news
+      POSTGRES_USER: liga
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U liga -d liga_news"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: liga-news-backend
+    restart: unless-stopped
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://liga:${POSTGRES_PASSWORD:-changeme}@db:5432/liga_news
+      - LLM_ENABLED=${LLM_ENABLED:-true}
+      - OLLAMA_BASE_URL=http://gpu1:11434
+      - OLLAMA_MODEL=qwen3:14b-q8_0
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - OPENROUTER_MODEL=${OPENROUTER_MODEL:-mistralai/mistral-7b-instruct:free}
+      # Embedding classifier pre-filter (runs on gpu1)
+      - CLASSIFIER_URL=http://gpu1:8082
+      - CLASSIFIER_THRESHOLD=${CLASSIFIER_THRESHOLD:-0.8}
+      - CLASSIFIER_ENABLED=${CLASSIFIER_ENABLED:-true}
+      - CLASSIFIER_USE_PRIORITY=${CLASSIFIER_USE_PRIORITY:-false}
+      - CLASSIFIER_USE_AK=${CLASSIFIER_USE_AK:-false}
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    volumes:
+      - backend-data:/app/data
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: liga-news-frontend
+    restart: unless-stopped
+    ports:
+      - "3000:80"
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:80/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  postgres-data:
+    name: liga-news-postgres-data
+  backend-data:
+    name: liga-news-data

--- a/news-aggregator/scripts/backup_db.sh
+++ b/news-aggregator/scripts/backup_db.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 # Liga News Database Backup Script
-# Creates timestamped SQLite backups with compression and rotation
+# Creates timestamped backups with compression and rotation
+# Supports both SQLite and PostgreSQL databases
 #
 # Usage:
-#   ./backup_db.sh                     # Backup local database
+#   ./backup_db.sh                     # Backup local database (auto-detect type)
 #   ./backup_db.sh --docker            # Backup from Docker container
 #   ./backup_db.sh --remote user@host:/path  # Copy backup to remote
 #   ./backup_db.sh --keep 14           # Keep 14 backups instead of default 7
 #
 # Environment variables:
-#   BACKUP_DIR    - Backup directory (default: ./backups)
-#   DB_PATH       - Local database path (default: ./backend/data/liga_news.db)
+#   DATABASE_URL     - Database connection URL (for PostgreSQL)
+#   BACKUP_DIR       - Backup directory (default: ./backups)
+#   DB_PATH          - Local SQLite database path (default: ./backend/data/liga_news.db)
 #   DOCKER_CONTAINER - Container name (default: liga-news-backend)
 
 set -euo pipefail
@@ -26,6 +28,7 @@ DOCKER_DB_PATH="/app/data/liga_news.db"
 KEEP_BACKUPS=7
 REMOTE_TARGET=""
 USE_DOCKER=false
+DATABASE_URL="${DATABASE_URL:-}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -36,6 +39,43 @@ NC='\033[0m' # No Color
 log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Detect database type from DATABASE_URL
+detect_db_type() {
+    if [[ -n "$DATABASE_URL" && "$DATABASE_URL" == postgresql* ]]; then
+        echo "postgresql"
+    elif [[ -n "$DATABASE_URL" && "$DATABASE_URL" == postgres* ]]; then
+        echo "postgresql"
+    else
+        echo "sqlite"
+    fi
+}
+
+# Parse PostgreSQL URL into components
+# postgresql+asyncpg://user:pass@host:port/dbname -> components
+parse_pg_url() {
+    local url="$1"
+    # Remove protocol prefix (postgresql+asyncpg:// or postgresql://)
+    url="${url#*://}"
+
+    # Extract user:pass@host:port/dbname
+    local userpass="${url%%@*}"
+    local hostportdb="${url#*@}"
+
+    PG_USER="${userpass%%:*}"
+    PG_PASS="${userpass#*:}"
+
+    local hostport="${hostportdb%%/*}"
+    PG_DB="${hostportdb#*/}"
+
+    PG_HOST="${hostport%%:*}"
+    PG_PORT="${hostport#*:}"
+
+    # Default port if not specified
+    if [[ "$PG_PORT" == "$PG_HOST" ]]; then
+        PG_PORT="5432"
+    fi
+}
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -60,6 +100,11 @@ while [[ $# -gt 0 ]]; do
             echo "  --remote HOST      Copy backup to remote (user@host:/path)"
             echo "  --keep N           Keep N most recent backups (default: 7)"
             echo "  -h, --help         Show this help message"
+            echo ""
+            echo "Environment variables:"
+            echo "  DATABASE_URL       PostgreSQL connection URL (auto-uses pg_dump)"
+            echo "  DB_PATH            SQLite database file path"
+            echo "  BACKUP_DIR         Directory for backup files"
             exit 0
             ;;
         *)
@@ -74,70 +119,134 @@ mkdir -p "$BACKUP_DIR"
 
 # Generate filename with timestamp
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-BACKUP_FILE="liga_news_${TIMESTAMP}.db"
-BACKUP_PATH="${BACKUP_DIR}/${BACKUP_FILE}"
+DB_TYPE=$(detect_db_type)
 
 echo "============================================"
 echo "  Liga News Database Backup"
 echo "============================================"
 echo ""
 log_info "Timestamp: $TIMESTAMP"
+log_info "Database type: $DB_TYPE"
 log_info "Backup directory: $BACKUP_DIR"
 
-# Create backup
-if $USE_DOCKER; then
-    log_info "Backing up from Docker container: $DOCKER_CONTAINER"
+# Create backup based on database type
+if [[ "$DB_TYPE" == "postgresql" ]]; then
+    BACKUP_FILE="liga_news_${TIMESTAMP}.dump"
+    BACKUP_PATH="${BACKUP_DIR}/${BACKUP_FILE}"
 
-    # Check if container is running
-    if ! docker ps --format '{{.Names}}' | grep -q "^${DOCKER_CONTAINER}$"; then
-        log_error "Container '$DOCKER_CONTAINER' is not running"
+    log_info "Backing up PostgreSQL database"
+
+    # Parse the URL
+    parse_pg_url "$DATABASE_URL"
+
+    if $USE_DOCKER; then
+        # Get DATABASE_URL from container
+        CONTAINER_DB_URL=$(docker exec "$DOCKER_CONTAINER" printenv DATABASE_URL 2>/dev/null || echo "")
+        if [[ -n "$CONTAINER_DB_URL" ]]; then
+            parse_pg_url "$CONTAINER_DB_URL"
+        fi
+
+        # Use pg_dump from container
+        log_info "Using pg_dump from container: $DOCKER_CONTAINER"
+        docker exec -e PGPASSWORD="$PG_PASS" "$DOCKER_CONTAINER" \
+            pg_dump -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" \
+            -F custom -f "/tmp/backup.dump"
+        docker cp "${DOCKER_CONTAINER}:/tmp/backup.dump" "$BACKUP_PATH"
+        docker exec "$DOCKER_CONTAINER" rm /tmp/backup.dump
+    else
+        # Check if pg_dump is available
+        if ! command -v pg_dump &> /dev/null; then
+            log_error "pg_dump command not found. Please install postgresql-client."
+            exit 1
+        fi
+
+        # Use pg_dump with custom format
+        PGPASSWORD="$PG_PASS" pg_dump -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" \
+            -F custom -f "$BACKUP_PATH"
+    fi
+
+    # Verify backup was created
+    if [[ ! -f "$BACKUP_PATH" ]]; then
+        log_error "Backup file was not created"
         exit 1
     fi
 
-    # Use sqlite3 backup command for consistent snapshot
-    docker exec "$DOCKER_CONTAINER" sqlite3 "$DOCKER_DB_PATH" ".backup '/tmp/backup.db'"
-    docker cp "${DOCKER_CONTAINER}:/tmp/backup.db" "$BACKUP_PATH"
-    docker exec "$DOCKER_CONTAINER" rm /tmp/backup.db
+    # Verify backup integrity using pg_restore --list
+    log_info "Verifying backup integrity..."
+    if pg_restore --list "$BACKUP_PATH" > /dev/null 2>&1; then
+        log_info "Integrity check: PASSED"
+    else
+        log_error "Integrity check: FAILED"
+        rm -f "$BACKUP_PATH"
+        exit 1
+    fi
+
+    # Get row counts for verification
+    ITEM_COUNT=$(PGPASSWORD="$PG_PASS" psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" \
+        -t -c "SELECT COUNT(*) FROM items;" 2>/dev/null | tr -d ' ' || echo "0")
+    SOURCE_COUNT=$(PGPASSWORD="$PG_PASS" psql -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" \
+        -t -c "SELECT COUNT(*) FROM sources;" 2>/dev/null | tr -d ' ' || echo "0")
+    log_info "Backup contains: $ITEM_COUNT items, $SOURCE_COUNT sources"
+
 else
-    log_info "Backing up local file: $DB_PATH"
+    # SQLite backup
+    BACKUP_FILE="liga_news_${TIMESTAMP}.db"
+    BACKUP_PATH="${BACKUP_DIR}/${BACKUP_FILE}"
 
-    # Check if database exists
-    if [[ ! -f "$DB_PATH" ]]; then
-        log_error "Database file not found: $DB_PATH"
+    if $USE_DOCKER; then
+        log_info "Backing up from Docker container: $DOCKER_CONTAINER"
+
+        # Check if container is running
+        if ! docker ps --format '{{.Names}}' | grep -q "^${DOCKER_CONTAINER}$"; then
+            log_error "Container '$DOCKER_CONTAINER' is not running"
+            exit 1
+        fi
+
+        # Use sqlite3 backup command for consistent snapshot
+        docker exec "$DOCKER_CONTAINER" sqlite3 "$DOCKER_DB_PATH" ".backup '/tmp/backup.db'"
+        docker cp "${DOCKER_CONTAINER}:/tmp/backup.db" "$BACKUP_PATH"
+        docker exec "$DOCKER_CONTAINER" rm /tmp/backup.db
+    else
+        log_info "Backing up local file: $DB_PATH"
+
+        # Check if database exists
+        if [[ ! -f "$DB_PATH" ]]; then
+            log_error "Database file not found: $DB_PATH"
+            exit 1
+        fi
+
+        # Check if sqlite3 is available
+        if ! command -v sqlite3 &> /dev/null; then
+            log_error "sqlite3 command not found. Please install sqlite3."
+            exit 1
+        fi
+
+        sqlite3 "$DB_PATH" ".backup '${BACKUP_PATH}'"
+    fi
+
+    # Verify backup was created
+    if [[ ! -f "$BACKUP_PATH" ]]; then
+        log_error "Backup file was not created"
         exit 1
     fi
 
-    # Check if sqlite3 is available
-    if ! command -v sqlite3 &> /dev/null; then
-        log_error "sqlite3 command not found. Please install sqlite3."
+    # Verify backup integrity
+    log_info "Verifying backup integrity..."
+    INTEGRITY_CHECK=$(sqlite3 "$BACKUP_PATH" "PRAGMA integrity_check;" 2>&1)
+    if [[ "$INTEGRITY_CHECK" == "ok" ]]; then
+        log_info "Integrity check: PASSED"
+    else
+        log_error "Integrity check: FAILED"
+        log_error "$INTEGRITY_CHECK"
+        rm -f "$BACKUP_PATH"
         exit 1
     fi
 
-    sqlite3 "$DB_PATH" ".backup '${BACKUP_PATH}'"
+    # Get item count for verification
+    ITEM_COUNT=$(sqlite3 "$BACKUP_PATH" "SELECT COUNT(*) FROM items;" 2>/dev/null || echo "0")
+    SOURCE_COUNT=$(sqlite3 "$BACKUP_PATH" "SELECT COUNT(*) FROM sources;" 2>/dev/null || echo "0")
+    log_info "Backup contains: $ITEM_COUNT items, $SOURCE_COUNT sources"
 fi
-
-# Verify backup was created
-if [[ ! -f "$BACKUP_PATH" ]]; then
-    log_error "Backup file was not created"
-    exit 1
-fi
-
-# Verify backup integrity
-log_info "Verifying backup integrity..."
-INTEGRITY_CHECK=$(sqlite3 "$BACKUP_PATH" "PRAGMA integrity_check;" 2>&1)
-if [[ "$INTEGRITY_CHECK" == "ok" ]]; then
-    log_info "Integrity check: PASSED"
-else
-    log_error "Integrity check: FAILED"
-    log_error "$INTEGRITY_CHECK"
-    rm -f "$BACKUP_PATH"
-    exit 1
-fi
-
-# Get item count for verification
-ITEM_COUNT=$(sqlite3 "$BACKUP_PATH" "SELECT COUNT(*) FROM items;" 2>/dev/null || echo "0")
-SOURCE_COUNT=$(sqlite3 "$BACKUP_PATH" "SELECT COUNT(*) FROM sources;" 2>/dev/null || echo "0")
-log_info "Backup contains: $ITEM_COUNT items, $SOURCE_COUNT sources"
 
 # Compress backup
 log_info "Compressing backup..."
@@ -162,12 +271,14 @@ if [[ -n "$REMOTE_TARGET" ]]; then
     fi
 fi
 
-# Rotate old backups
+# Rotate old backups (match both .db.gz and .dump.gz)
 log_info "Rotating old backups (keeping $KEEP_BACKUPS)..."
 DELETED=0
-while IFS= read -r OLD_BACKUP; do
-    rm -v "$OLD_BACKUP" 2>/dev/null && ((DELETED++)) || true
-done < <(ls -t "${BACKUP_DIR}"/liga_news_*.db.gz 2>/dev/null | tail -n +$((KEEP_BACKUPS + 1)))
+for pattern in "liga_news_*.db.gz" "liga_news_*.dump.gz"; do
+    while IFS= read -r OLD_BACKUP; do
+        rm -v "$OLD_BACKUP" 2>/dev/null && ((DELETED++)) || true
+    done < <(ls -t "${BACKUP_DIR}"/$pattern 2>/dev/null | tail -n +$((KEEP_BACKUPS + 1)))
+done
 
 if [[ $DELETED -gt 0 ]]; then
     log_info "Deleted $DELETED old backup(s)"


### PR DESCRIPTION
## Summary
- Adds PostgreSQL as an alternative database backend while keeping SQLite as the default
- Creates database-agnostic JSON extraction helper that works on both databases
- Updates migrations to use SQLAlchemy Inspector for database-agnostic schema introspection
- Adds CI workflow testing both SQLite and PostgreSQL

## Changes
- **backend/requirements.txt**: Added asyncpg and psycopg dependencies
- **backend/database.py**: Added `is_sqlite()`, `is_postgresql()`, and `json_extract_path()` helper
- **backend/main.py**: Updated migrations to use SQLAlchemy Inspector
- **backend/api/*.py, services/*.py**: Updated JSON queries to use `json_extract_path`
- **backend/Dockerfile**: Added postgresql-client for backups
- **backend/tests/conftest.py**: Made test database configurable via TEST_DATABASE_URL
- **scripts/backup_db.sh**: Added PostgreSQL backup support (pg_dump)
- **docker-compose.postgres.yml**: New PostgreSQL deployment configuration
- **.github/workflows/test.yml**: CI running tests on both SQLite and PostgreSQL
- **.env.example**: Added PostgreSQL connection examples

## Test plan
- [x] SQLite tests pass (410+ passed)
- [x] PostgreSQL tests pass (411 passed)
- [ ] Verify CI workflow runs successfully
- [ ] Test docker-compose.postgres.yml deployment

## Usage
SQLite (default, no changes needed):
```bash
DATABASE_URL=sqlite+aiosqlite:///./data/news.db
```

PostgreSQL:
```bash
DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/liga_news
docker compose -f docker-compose.postgres.yml up -d
```

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)