### PR TITLE
fix(prod): move liga-news-backend off 192.168.0.200 to .208

### DIFF
--- a/news-aggregator/docker-compose.prod.yml
+++ b/news-aggregator/docker-compose.prod.yml
@@ -21,7 +21,7 @@ networks:
   lan:
     # Shared external macvlan network created once on the host:
     #   docker network create -d macvlan --subnet 192.168.0.0/24 \
-    #     --gateway 192.168.0.1 --ip-range 192.168.0.200/29 \
+    #     --gateway 192.168.0.1 --ip-range 192.168.0.208/29 \
     #     -o parent=ens18 lan-shared
     external: true
     name: lan-shared
@@ -173,7 +173,7 @@ services:
     networks:
       default:  # For db connectivity
       lan:
-        ipv4_address: 192.168.0.200  # Static IP on LAN for WoL
+        ipv4_address: 192.168.0.208  # Static IP on LAN for WoL
       ollamaproxy:  # Reach Ollama proxy backplane by name (http://ollamaproxy:11434)
 
   frontend:


### PR DESCRIPTION
## Summary

Retroactive PR for commit 28f8475, already merged to `main` via direct fast-forward on 2026-05-02. Documenting for the paper trail.

The D-Link DGS-1210-28P managed switch sits on `192.168.0.200`, the same IP `liga-news-backend` was statically pinned to on the `lan-shared` macvlan. Docker macvlan IPAM does not consult the LAN, so the collision was silent — until traffic bursts triggered ARP storms that wedged the switch port. This is the likely cause of the 2026-01-04 5h LAN outage and the link flaps observed on 2026-05-02.

## Changes

- `liga-news-backend` static IP: `.200` → `.208`
- `lan-shared` macvlan range: `.200/29` → `.208/29` (so .200 is permanently outside Docker's pool)
- Switch IP `.200` also reserved on the Fritz.Box for MAC `40:9B:CD:16:84:60` (manual config, not in this diff)

## Long-term fix

The static `.208` pin is interim. Docker's macvlan driver fundamentally cannot consult the LAN's DHCP server. A separate fork at `christian-kamien/docker-net-dhcp` is in progress to add a Docker IPAM plugin that DHCPs from the Fritz.Box; once it lands, the static pin in `docker-compose.prod.yml` goes away entirely.

## Test plan

- [x] Backend reachable on `.208` (HTTP 200 from `/api/admin/stats`)
- [x] Ping from gpu1 to `.208` clean
- [x] No new link-flap entries in `dmesg` on docker-ai since deploy
- [ ] 24h soak — verify switch port stays up under regular traffic load

🤖 Generated with [Claude Code](https://claude.com/claude-code)